### PR TITLE
Updated files processing

### DIFF
--- a/Common/Common.csproj
+++ b/Common/Common.csproj
@@ -17,13 +17,13 @@
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
-    <Reference Include="MessagePack, Version=1.7.3.4, Culture=neutral, PublicKeyToken=b4a0369545f0a1be, processorArchitecture=MSIL">
-      <HintPath>..\packages\MessagePack.1.7.3.4\lib\net45\MessagePack.dll</HintPath>
+    <Reference Include="MessagePack">
+      <HintPath>..\packages\MessagePack.1.9.11\lib\net45\MessagePack.dll</HintPath>
     </Reference>
-    <Reference Include="System.Threading.Tasks.Extensions, Version=4.2.0.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+    <Reference Include="System.Threading.Tasks.Extensions">
       <HintPath>..\packages\System.Threading.Tasks.Extensions.4.5.4\lib\portable-net45+win8+wp8+wpa81\System.Threading.Tasks.Extensions.dll</HintPath>
     </Reference>
-    <Reference Include="System.ValueTuple, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+    <Reference Include="System.ValueTuple">
       <HintPath>..\packages\System.ValueTuple.4.5.0\lib\netstandard1.0\System.ValueTuple.dll</HintPath>
     </Reference>
   </ItemGroup>

--- a/Common/app.config
+++ b/Common/app.config
@@ -4,11 +4,23 @@
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="System.ValueTuple" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-4.0.3.0" newVersion="4.0.3.0"/>
+        <bindingRedirect oldVersion="0.0.0.0-4.5.0" newVersion="4.5.0"/>
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Threading.Tasks.Extensions" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral"/>
         <bindingRedirect oldVersion="0.0.0.0-4.2.0.1" newVersion="4.2.0.1"/>
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Reflection.Emit"/>
+        <bindingRedirect oldVersion="0.0.0.0-4.7.0" newVersion="4.7.0"/>
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Reflection.Emit.Lightweight"/>
+        <bindingRedirect oldVersion="0.0.0.0-4.7.0" newVersion="4.7.0"/>
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Runtime.Serialization.Primitives"/>
+        <bindingRedirect oldVersion="0.0.0.0-4.3.0" newVersion="4.3.0"/>
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/Common/packages.config
+++ b/Common/packages.config
@@ -1,8 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="MessagePack" version="1.7.3.4" targetFramework="net45" />
+  <package id="MessagePack" version="1.9.11" targetFramework="net45" />
   <package id="MessagePackAnalyzer" version="1.6.0" targetFramework="net45" />
   <package id="System.Runtime.CompilerServices.Unsafe" version="4.5.3" targetFramework="net45" />
   <package id="System.Threading.Tasks.Extensions" version="4.5.4" targetFramework="net45" />
   <package id="System.ValueTuple" version="4.5.0" targetFramework="net45" />
+  <package id="System.Reflection.Emit" version="4.7.0" targetFramework="net45" />
+  <package id="System.Reflection.Emit.Lightweight" version="4.7.0" targetFramework="net45" />
+  <package id="System.Runtime.Serialization.Primitives" version="4.3.0" targetFramework="net45" />
 </packages>

--- a/MolecularFormulaGenerator/File manage/FormulaResultParcer.cs
+++ b/MolecularFormulaGenerator/File manage/FormulaResultParcer.cs
@@ -33,9 +33,14 @@ namespace Rfx.Riken.OsakaUniv
                 var versionNum = 1;
                 var isHeaderChecked = false;
                
-                while (sr.Peek() > -1)
+                while (!sr.EndOfStream)
                 {
                     wkstr = sr.ReadLine();
+
+                    if (string.IsNullOrEmpty(wkstr))
+                    {
+                        continue;
+                    }
 
                     if (isHeaderChecked == false) {
                         if (wkstr.Contains("Version:")) {
@@ -508,7 +513,7 @@ namespace Rfx.Riken.OsakaUniv
         /// <param name="results">Add the list of formularesult</param>
         public static void FormulaResultsWriter(string filePath, List<FormulaResult> results)
         {
-            using (var sw = new StreamWriter(filePath, false, Encoding.ASCII))
+            using (var sw = new StreamWriter(filePath, true, Encoding.ASCII))
             {
                 sw.WriteLine("Version: 2");
                 foreach (var result in results) { formulaStreamWriter(sw, result); }

--- a/MolecularFormulaGenerator/File manage/RawDataParcer.cs
+++ b/MolecularFormulaGenerator/File manage/RawDataParcer.cs
@@ -36,7 +36,8 @@ namespace Rfx.Riken.OsakaUniv
                 double rt;
                 if (double.TryParse(wkstr.Split(':')[1].Trim(), out rt)) rawData.RetentionIndex = rt; else rawData.RetentionIndex = -1;
             }
-            else if (Regex.IsMatch(wkstr, "PRECURSORMZ:", RegexOptions.IgnoreCase))
+            else if (Regex.IsMatch(wkstr, "PRECURSORMZ:", RegexOptions.IgnoreCase) ||
+                     Regex.IsMatch(wkstr, "MW:", RegexOptions.IgnoreCase))
             {
                 double mz;
                 if (double.TryParse(wkstr.Split(':')[1].Trim(), out mz)) rawData.PrecursorMz = mz;
@@ -255,8 +256,11 @@ namespace Rfx.Riken.OsakaUniv
                     wkstr = sr.ReadLine();
                     if (string.IsNullOrEmpty(wkstr))
                     {
-                        rawDataList.Add(rawData);
-                        rawData = new RawData(){ RawdataFilePath = filePath };
+                        if (rawData.Name != null)
+                        {
+                            rawDataList.Add(rawData);
+                            rawData = new RawData(){ RawdataFilePath = filePath };
+                        }
                         continue;
                     }
                     #region parcer

--- a/MolecularFormulaGenerator/MolecularFormulaFinder.csproj
+++ b/MolecularFormulaGenerator/MolecularFormulaFinder.csproj
@@ -39,11 +39,11 @@
     <Reference Include="MathNet.Numerics, Version=3.20.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\MathNet.Numerics.3.20.0\lib\net40\MathNet.Numerics.dll</HintPath>
     </Reference>
-    <Reference Include="MessagePack, Version=1.7.3.4, Culture=neutral, PublicKeyToken=b4a0369545f0a1be, processorArchitecture=MSIL">
-      <HintPath>..\packages\MessagePack.1.7.3.4\lib\net45\MessagePack.dll</HintPath>
+    <Reference Include="MessagePack">
+      <HintPath>..\packages\MessagePack.1.9.11\lib\net45\MessagePack.dll</HintPath>
     </Reference>
-    <Reference Include="System.Threading.Tasks.Extensions, Version=4.1.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Threading.Tasks.Extensions.4.3.0\lib\portable-net45+win8+wp8+wpa81\System.Threading.Tasks.Extensions.dll</HintPath>
+    <Reference Include="System.Threading.Tasks.Extensions">
+      <HintPath>..\packages\System.Threading.Tasks.Extensions.4.5.4\lib\portable-net45+win8+wp8+wpa81\System.Threading.Tasks.Extensions.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/MolecularFormulaGenerator/packages.config
+++ b/MolecularFormulaGenerator/packages.config
@@ -4,6 +4,6 @@
   <package id="Accord.Math" version="3.6.0" targetFramework="net40" />
   <package id="Accord.Statistics" version="3.6.0" targetFramework="net40" />
   <package id="MathNet.Numerics" version="3.20.0" targetFramework="net40" />
-  <package id="MessagePack" version="1.7.3.4" targetFramework="net45" />
-  <package id="System.Threading.Tasks.Extensions" version="4.3.0" targetFramework="net45" />
+  <package id="MessagePack" version="1.9.11" targetFramework="net45" />
+  <package id="System.Threading.Tasks.Extensions" version="4.5.4" targetFramework="net45" />
 </packages>

--- a/MsfinderCommon/Process/PeakAssigner.cs
+++ b/MsfinderCommon/Process/PeakAssigner.cs
@@ -25,17 +25,17 @@ namespace Riken.Metabolomics.MsfinderCommon.Process
             var formualResults = new List<FormulaResult>() { formulaResult };
             FormulaResultParcer.FormulaResultsWriter(analysisFile.FormulaFilePath, formualResults);
 
-            var structureFiles = System.IO.Directory.GetFiles(analysisFile.StructureFolderPath, "*.sfd");
-            if (structureFiles.Length > 0) FileStorageUtility.DeleteSfdFiles(structureFiles);
+            //var structureFiles = System.IO.Directory.GetFiles(analysisFile.StructureFolderPath, "*.sfd");
+            //if (structureFiles.Length > 0) FileStorageUtility.DeleteSfdFiles(structureFiles);
 
-            var exportStructureFilePath = FileStorageUtility.GetStructureDataFilePath(analysisFile.StructureFolderPath, formulaResult.Formula.FormulaString);
+            var exportStructureFilePath = FileStorageUtility.GetStructureDataFilePath(analysisFile.StructureFolderPath, analysisFile.RawDataFileName);
             if (rawData.Ms2PeakNumber <= 0 || rawData.Smiles == null || rawData.Smiles == string.Empty) return;
             
             var structureQuery = new ExistStructureQuery(rawData.Name, rawData.InchiKey, rawData.InchiKey, new List<int>(), formulaResult.Formula, rawData.Smiles, string.Empty, 0, new DatabaseQuery());
             if (structureQuery == null) return;
 
             var eQueries = new List<ExistStructureQuery>() { structureQuery };
-            System.IO.File.Create(exportStructureFilePath).Close();
+            //System.IO.File.Create(exportStructureFilePath).Close();
 
             var adductIon = AdductIonParcer.GetAdductIonBean(rawData.PrecursorType);
             var centroidSpectrum = FragmentAssigner.GetCentroidMsMsSpectrum(rawData);

--- a/MsfinderCommon/Utility/FileStorageUtility.cs
+++ b/MsfinderCommon/Utility/FileStorageUtility.cs
@@ -510,7 +510,11 @@ namespace Riken.Metabolomics.MsfinderCommon.Utility {
                         sfdResultMerge(sfdResults, sfdResult, formulaString);
                     }
                     //sfdResults = sfdResults.OrderByDescending(n => n.TotalScore).ToList();
-                    writeResultAsMsp(sw, rawData, formulaResults, sfdResults, param);
+                    
+                    if (rawData.Count == formulaResults.Count && rawData.Count == sfdResults.Count)
+                    {
+                        writeResultAsMsp(sw, rawData, formulaResults, sfdResults, param);
+                    }
                 }
             }
         }

--- a/MsfinderCommon/Utility/FileStorageUtility.cs
+++ b/MsfinderCommon/Utility/FileStorageUtility.cs
@@ -495,7 +495,7 @@ namespace Riken.Metabolomics.MsfinderCommon.Utility {
                 foreach (var rawfile in files)
                 {
                     var rawData = RawDataParcer.RawDataFileReader(rawfile.RawDataFilePath, param);
-                    var formulaResults = FormulaResultParcer.FormulaResultReader(rawfile.FormulaFilePath, out error).OrderByDescending(n => n.TotalScore).ToList();
+                    var formulaResults = FormulaResultParcer.FormulaResultReader(rawfile.FormulaFilePath, out error); //.OrderByDescending(n => n.TotalScore).ToList();
                     if (error != string.Empty) {
                         Console.WriteLine(error);
                     }
@@ -509,40 +509,40 @@ namespace Riken.Metabolomics.MsfinderCommon.Utility {
                         var formulaString = System.IO.Path.GetFileNameWithoutExtension(sfdFile);
                         sfdResultMerge(sfdResults, sfdResult, formulaString);
                     }
-                    sfdResults = sfdResults.OrderByDescending(n => n.TotalScore).ToList();
+                    //sfdResults = sfdResults.OrderByDescending(n => n.TotalScore).ToList();
                     writeResultAsMsp(sw, rawData, formulaResults, sfdResults, param);
                 }
             }
         }
 
         private static void writeResultAsMsp(StreamWriter sw, List<Rfx.Riken.OsakaUniv.RawData> rawDataList, List<FormulaResult> formulaResults, List<FragmenterResult> sfdResults, AnalysisParamOfMsfinder param) {
-            foreach (var rawData in rawDataList) {
-                sw.WriteLine("NAME: " + rawData.Name);
-                sw.WriteLine("SCANNUMBER: " + rawData.ScanNumber);
-                sw.WriteLine("RETENTIONTIME: " + rawData.RetentionTime);
-                sw.WriteLine("RETENTIONINDEX: " + rawData.RetentionIndex);
-                sw.WriteLine("PRECURSORMZ: " + rawData.PrecursorMz);
-                sw.WriteLine("PRECURSORTYPE: " + rawData.PrecursorType);
-                sw.WriteLine("IONMODE: " + rawData.IonMode);
-                sw.WriteLine("SPECTRUMTYPE: " + rawData.SpectrumType);
-                sw.WriteLine("FORMULA: " + rawData.Formula);
-                sw.WriteLine("INCHIKEY: " + rawData.InchiKey);
-                sw.WriteLine("INCHI: " + rawData.Inchi);
-                sw.WriteLine("SMILES: " + rawData.Smiles);
-                sw.WriteLine("AUTHORS: " + rawData.Authors);
-                sw.WriteLine("COLLISIONENERGY: " + rawData.CollisionEnergy);
-                sw.WriteLine("INSTRUMENT: " + rawData.Instrument);
-                sw.WriteLine("INSTRUMENTTYPE: " + rawData.InstrumentType);
-                sw.WriteLine("IONIZATION: " + rawData.Ionization);
-                sw.WriteLine("LICENSE: " + rawData.License);
-                sw.WriteLine("COMMENT: " + rawData.Comment);
+            foreach (var index in Enumerable.Range(0, rawDataList.Count)) {
+                sw.WriteLine("NAME: " + rawDataList[index].Name);
+                sw.WriteLine("SCANNUMBER: " + rawDataList[index].ScanNumber);
+                sw.WriteLine("RETENTIONTIME: " + rawDataList[index].RetentionTime);
+                sw.WriteLine("RETENTIONINDEX: " + rawDataList[index].RetentionIndex);
+                sw.WriteLine("PRECURSORMZ: " + rawDataList[index].PrecursorMz);
+                sw.WriteLine("PRECURSORTYPE: " + rawDataList[index].PrecursorType);
+                sw.WriteLine("IONMODE: " + rawDataList[index].IonMode);
+                sw.WriteLine("SPECTRUMTYPE: " + rawDataList[index].SpectrumType);
+                sw.WriteLine("FORMULA: " + rawDataList[index].Formula);
+                sw.WriteLine("INCHIKEY: " + rawDataList[index].InchiKey);
+                sw.WriteLine("INCHI: " + rawDataList[index].Inchi);
+                sw.WriteLine("SMILES: " + rawDataList[index].Smiles);
+                sw.WriteLine("AUTHORS: " + rawDataList[index].Authors);
+                sw.WriteLine("COLLISIONENERGY: " + rawDataList[index].CollisionEnergy);
+                sw.WriteLine("INSTRUMENT: " + rawDataList[index].Instrument);
+                sw.WriteLine("INSTRUMENTTYPE: " + rawDataList[index].InstrumentType);
+                sw.WriteLine("IONIZATION: " + rawDataList[index].Ionization);
+                sw.WriteLine("LICENSE: " + rawDataList[index].License);
+                sw.WriteLine("COMMENT: " + rawDataList[index].Comment);
 
-                var spectra = rawData.Ms2Spectrum.PeakList.OrderBy(n => n.Mz).ToList();
+                var spectra = rawDataList[index].Ms2Spectrum.PeakList.OrderBy(n => n.Mz).ToList();
                 var maxIntensity = spectra.Max(n => n.Intensity);
                 var spectraList = new List<string>();
-                var ms2Peaklist = FragmentAssigner.GetCentroidMsMsSpectrum(rawData);
+                var ms2Peaklist = FragmentAssigner.GetCentroidMsMsSpectrum(rawDataList[index]);
                 //var commentList = FragmentAssigner.IsotopicPeakAssignmentForComment(ms2Peaklist, param.Mass2Tolerance, param.MassTolType);
-                for (int i = 0; i < rawData.Ms2PeakNumber; i++)
+                for (int i = 0; i < rawDataList[index].Ms2PeakNumber; i++)
                 {
                     var mz = spectra[i].Mz;
                     var intensity = spectra[i].Intensity;
@@ -550,7 +550,7 @@ namespace Riken.Metabolomics.MsfinderCommon.Utility {
                     var comment = "";
 
                     var originalComment = spectra[i].Comment;
-                    var additionalComment = getProductIonComment(mz, formulaResults, sfdResults, rawData.IonMode);
+                    var additionalComment = getProductIonComment(mz, formulaResults[index], sfdResults[index], rawDataList[index].IonMode);
                     if (originalComment != "")
                         comment = originalComment + "; " + additionalComment;
                     else
@@ -572,13 +572,13 @@ namespace Riken.Metabolomics.MsfinderCommon.Utility {
             }
         }
 
-        private static string getProductIonComment(double mz, List<FormulaResult> formulaResults, List<FragmenterResult> sfdResults, IonMode ionMode) {
-            if (sfdResults == null || sfdResults.Count == 0) return string.Empty;
-            if (formulaResults == null || formulaResults.Count == 0) return string.Empty;
+        private static string getProductIonComment(double mz, FormulaResult formulaResults, FragmenterResult sfdResults, IonMode ionMode) {
+            if (sfdResults == null ) return string.Empty;
+            if (formulaResults == null ) return string.Empty;
 
-            var productIonResult = formulaResults[0].ProductIonResult;
-            var annotationResult = formulaResults[0].AnnotatedIonResult;
-            var fragments = sfdResults[0].FragmentPics;
+            var productIonResult = formulaResults.ProductIonResult;
+            var annotationResult = formulaResults.AnnotatedIonResult;
+            var fragments = sfdResults.FragmentPics;
             if (fragments == null || fragments.Count == 0) { return ""; }
 
             foreach (var frag in fragments) {

--- a/MsfinderCommon/app.config
+++ b/MsfinderCommon/app.config
@@ -4,7 +4,7 @@
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="System.ValueTuple" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-4.0.3.0" newVersion="4.0.3.0"/>
+        <bindingRedirect oldVersion="0.0.0.0-4.5.0" newVersion="4.5.0"/>
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Threading.Tasks.Extensions" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral"/>

--- a/MsfinderConsoleApp/App.config
+++ b/MsfinderConsoleApp/App.config
@@ -11,11 +11,23 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.ValueTuple" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-4.0.3.0" newVersion="4.0.3.0"/>
+        <bindingRedirect oldVersion="0.0.0.0-4.5.0" newVersion="4.5.0"/>
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Threading.Tasks.Extensions" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral"/>
         <bindingRedirect oldVersion="0.0.0.0-4.2.0.1" newVersion="4.2.0.1"/>
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Reflection.Emit"/>
+        <bindingRedirect oldVersion="0.0.0.0-4.7.0" newVersion="4.7.0"/>
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Reflection.Emit.Lightweight"/>
+        <bindingRedirect oldVersion="0.0.0.0-4.7.0" newVersion="4.7.0"/>
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Runtime.Serialization.Primitives"/>
+        <bindingRedirect oldVersion="0.0.0.0-4.3.0" newVersion="4.3.0"/>
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/MsfinderConsoleApp/Process/AnnotateProcess.cs
+++ b/MsfinderConsoleApp/Process/AnnotateProcess.cs
@@ -89,6 +89,15 @@ namespace Riken.Metabolomics.MsfinderConsoleApp.Process {
             #endregion
 
             Console.WriteLine("Start processing..");
+
+            foreach(var file in this.queryFiles){
+                var structureFile = System.IO.Directory.GetFiles(file.StructureFolderPath, "*.sfd");
+                if (structureFile.Length > 0) FileStorageUtility.DeleteSfdFiles(structureFile);
+
+                var formulaFile = System.IO.Directory.GetFiles(Path.GetDirectoryName(file.FormulaFilePath), $"{file.FormulaFileName}.fgt");
+                if (formulaFile.Length > 0) FileStorageUtility.DeleteSfdFiles(formulaFile);
+            }
+
             executeProcess();
             FileStorageUtility.PeakAnnotationResultExportAsMsp(input, this.param, outputfolder);
             return 1;
@@ -100,13 +109,13 @@ namespace Riken.Metabolomics.MsfinderConsoleApp.Process {
 
             var progress = 0;
 
-            Parallel.ForEach(this.queryFiles, file => {
+            foreach(var file in this.queryFiles){
                 var rawDataFilePath = file.RawDataFilePath;
                 var formulaFilePath = file.FormulaFilePath;
                 var rawDataList = RawDataParcer.RawDataFileReader(file.RawDataFilePath, param);
 
                 foreach(var rawData in rawDataList){
-                    if (rawData.Formula == null || rawData.Formula == string.Empty || rawData.Smiles == null || rawData.Smiles == string.Empty) return;
+                    if (rawData.Formula == null || rawData.Formula == string.Empty || rawData.Smiles == null || rawData.Smiles == string.Empty) return 1;
 
                     if (param.IsUseEiFragmentDB)
                         PeakAssigner.Process(file, rawData, param, productIonDB, neutralLossDB, existFormulaDB, eiFragmentDB, fragmentOntologyDB);
@@ -123,7 +132,7 @@ namespace Riken.Metabolomics.MsfinderConsoleApp.Process {
                         Console.WriteLine("Fragment annotation finished: {0} / {1}", progress, queryCount);
                     }
                 }
-            });
+            }
             return 1;
         }
 

--- a/StructureFinder/Parser/FragmenterResultParcer.cs
+++ b/StructureFinder/Parser/FragmenterResultParcer.cs
@@ -337,7 +337,7 @@ namespace Riken.Metabolomics.StructureFinder.Parser
 
                 fragmenterResults.Add(result);
             }
-            return fragmenterResults.OrderByDescending(n => n.TotalScore).ToList();
+            return fragmenterResults;//.OrderByDescending(n => n.TotalScore).ToList();
         }
 
         /// <summary>

--- a/StructureFinder/StructureFinder.csproj
+++ b/StructureFinder/StructureFinder.csproj
@@ -54,14 +54,14 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\IKVM.7.2.4630.5\lib\IKVM.Runtime.dll</HintPath>
     </Reference>
-    <Reference Include="MessagePack, Version=1.7.3.4, Culture=neutral, PublicKeyToken=b4a0369545f0a1be, processorArchitecture=MSIL">
-      <HintPath>..\packages\MessagePack.1.7.3.4\lib\net45\MessagePack.dll</HintPath>
+    <Reference Include="MessagePack">
+      <HintPath>..\packages\MessagePack.1.9.11\lib\net45\MessagePack.dll</HintPath>
     </Reference>
-    <Reference Include="System.Threading.Tasks.Extensions, Version=4.1.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Threading.Tasks.Extensions.4.3.0\lib\portable-net45+win8+wp8+wpa81\System.Threading.Tasks.Extensions.dll</HintPath>
+    <Reference Include="System.Threading.Tasks.Extensions">
+      <HintPath>..\packages\System.Threading.Tasks.Extensions.4.5.4\lib\portable-net45+win8+wp8+wpa81\System.Threading.Tasks.Extensions.dll</HintPath>
     </Reference>
-    <Reference Include="System.ValueTuple, Version=4.0.1.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.ValueTuple.4.3.0\lib\netstandard1.0\System.ValueTuple.dll</HintPath>
+    <Reference Include="System.ValueTuple">
+      <HintPath>..\packages\System.ValueTuple.4.5.0\lib\netstandard1.0\System.ValueTuple.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/StructureFinder/packages.config
+++ b/StructureFinder/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="IKVM" version="7.2.4630.5" targetFramework="net40" />
-  <package id="MessagePack" version="1.7.3.4" targetFramework="net45" />
-  <package id="System.Threading.Tasks.Extensions" version="4.3.0" targetFramework="net45" />
+  <package id="MessagePack" version="1.9.11" targetFramework="net45" />
+  <package id="System.Threading.Tasks.Extensions" version="4.5.4" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
This PR includes the following:

- updated read and write function of the formula result to read and write formula for multiple spectra #18
- updated read and write function of the sfdresult to read and write single sfd file for multiple spectra #19 
- updated input read function to handle multiple blank lines as a separator between spectra #14 
- updated read function to accept either MW or PRECURSORMZ #13 
- Disabled parallelism over files #15   
- added check in peakannotation function to continue only if the input file, formula result and the sfd file count have same count
- updated System.ValueTuple version across the projects
- updated System.Threading.Tasks.Extensions version across the projects
- updated MessagePack version across the projects

closes #18 closes #19 closes #14 closes #13 closes #15