### PR TITLE
Added functionality to log smiles in smi format

### DIFF
--- a/MsfinderCommon/Process/PeakAssigner.cs
+++ b/MsfinderCommon/Process/PeakAssigner.cs
@@ -44,10 +44,16 @@ namespace Riken.Metabolomics.MsfinderCommon.Process
             var curatedPeaklist = getCuratedPeaklist(formulaResult.ProductIonResult);
             
             var results = MainProcess.Fragmenter(eQueries, rawData, curatedPeaklist, refinedPeaklist, adductIon, formulaResult, param, fragmentDB, fragmentOntologies);
-
+            
             foreach (var result in results) {
                 result.TotalScore += formulaResult.TotalScore;
                 result.Ontology = rawData.Ontology;
+            }
+            if (results.Count == 0)
+            {
+            // If the results is 0, write to a file in SMI format
+                var logSmileFilePath = FileStorageUtility.GetSmileLogFilePath(analysisFile.FormulaFilePath);
+                FileStorageUtility.WriteToSmiFile(rawData.Smiles, logSmileFilePath);
             }
 
             FragmenterResultParcer.FragmenterResultWriter(exportStructureFilePath, results, true);

--- a/MsfinderCommon/Process/PeakAssigner.cs
+++ b/MsfinderCommon/Process/PeakAssigner.cs
@@ -26,7 +26,7 @@ namespace Riken.Metabolomics.MsfinderCommon.Process
             FormulaResultParcer.FormulaResultsWriter(analysisFile.FormulaFilePath, formualResults);
 
             //var structureFiles = System.IO.Directory.GetFiles(analysisFile.StructureFolderPath, "*.sfd");
-            //if (structureFiles.Length > 0) FileStorageUtility.DeleteSfdFiles(structureFiles);
+            //if (structureFiles.Length > 0) FileStorageUtility.DeleteFiles(structureFiles);
 
             var exportStructureFilePath = FileStorageUtility.GetStructureDataFilePath(analysisFile.StructureFolderPath, analysisFile.RawDataFileName);
             if (rawData.Ms2PeakNumber <= 0 || rawData.Smiles == null || rawData.Smiles == string.Empty) return;

--- a/MsfinderCommon/Utility/FileStorageUtility.cs
+++ b/MsfinderCommon/Utility/FileStorageUtility.cs
@@ -473,20 +473,48 @@ namespace Riken.Metabolomics.MsfinderCommon.Utility {
                 return folderPath + "/" + formula + "." + SaveFileFormat.sfd;
             }
         }
+        public static string GetSmileLogFilePath(string folderPath)
+        {
+            folderPath = Path.GetDirectoryName(folderPath);
 
-        public static void DeleteSfdFiles(string[] structureFiles) {
-            foreach (var file in structureFiles) {
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                return folderPath + "\\" + "log_smiles.smi";
+            }
+            else
+            {
+                return folderPath + "/" + "log_smiles.smi";
+            }
+        }
+        public static void DeleteSfdFiles(string[] structureFiles)
+        {
+            foreach (var file in structureFiles)
+            {
                 File.Delete(file);
+            }
+        }
+        public static void WriteToSmiFile(string smile, string filePath)
+        {
+            try
+            {
+                using (StreamWriter sw = new StreamWriter(filePath, true, Encoding.ASCII))
+                {
+                    sw.WriteLine(smile);
+                }
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"Error writing to SMI log file: {ex.Message}");
             }
         }
         public static void PeakAnnotationResultExportAsMsp(string input, AnalysisParamOfMsfinder param, string exportFilePath)
         {
             using (var sw = new StreamWriter(exportFilePath, false, Encoding.ASCII))
             {
-                var files =  FileStorageUtility.GetAnalysisFileBeanCollection(input);
+                var files = FileStorageUtility.GetAnalysisFileBeanCollection(input);
                 if (File.Exists(input))
                     files = FileStorageUtility.GetSingleAnalysisFileBeanCollection(input, exportFilePath);
-                    
+
                 ///var files = FileStorageUtility.GetAnalysisFileBeanCollection(input);
                 //var files = queryFiles;
                 //var param = mainWindowVM.DataStorageBean.AnalysisParameter;
@@ -496,7 +524,8 @@ namespace Riken.Metabolomics.MsfinderCommon.Utility {
                 {
                     var rawData = RawDataParcer.RawDataFileReader(rawfile.RawDataFilePath, param);
                     var formulaResults = FormulaResultParcer.FormulaResultReader(rawfile.FormulaFilePath, out error); //.OrderByDescending(n => n.TotalScore).ToList();
-                    if (error != string.Empty) {
+                    if (error != string.Empty)
+                    {
                         Console.WriteLine(error);
                     }
 
@@ -510,10 +539,14 @@ namespace Riken.Metabolomics.MsfinderCommon.Utility {
                         sfdResultMerge(sfdResults, sfdResult, rawData);
                     }
                     //sfdResults = sfdResults.OrderByDescending(n => n.TotalScore).ToList();
-                    
+
                     if (rawData.Count == formulaResults.Count && rawData.Count == sfdResults.Count)
                     {
                         writeResultAsMsp(sw, rawData, formulaResults, sfdResults, param);
+                    }
+                    else
+                    {
+                        Console.WriteLine($"Fragment annotation failed\nCount of rawData ({rawData.Count}), formulaResults ({formulaResults.Count}), and sfdResults ({sfdResults.Count}) are not equal");
                     }
                 }
             }

--- a/MsfinderCommon/Utility/FileStorageUtility.cs
+++ b/MsfinderCommon/Utility/FileStorageUtility.cs
@@ -467,26 +467,17 @@ namespace Riken.Metabolomics.MsfinderCommon.Utility {
         }
 
         public static string GetStructureDataFilePath(string folderPath, string formula) {
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows)){
-                return folderPath + "\\" + formula + "." + SaveFileFormat.sfd;
-            }else{
-                return folderPath + "/" + formula + "." + SaveFileFormat.sfd;
-            }
+            return Path.Combine(folderPath, formula + "." + SaveFileFormat.sfd);
         }
         public static string GetSmileLogFilePath(string folderPath)
         {
             folderPath = Path.GetDirectoryName(folderPath);
+            
+            string fileName = "log_smiles.smi";
 
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-            {
-                return folderPath + "\\" + "log_smiles.smi";
-            }
-            else
-            {
-                return folderPath + "/" + "log_smiles.smi";
-            }
+            return Path.Combine(folderPath, fileName);
         }
-        public static void DeleteSfdFiles(string[] structureFiles)
+        public static void DeleteFiles(string[] structureFiles)
         {
             foreach (var file in structureFiles)
             {

--- a/MsfinderConsoleApp/Process/AnnotateProcess.cs
+++ b/MsfinderConsoleApp/Process/AnnotateProcess.cs
@@ -92,14 +92,14 @@ namespace Riken.Metabolomics.MsfinderConsoleApp.Process {
 
             foreach(var file in this.queryFiles){
                 var structureFile = System.IO.Directory.GetFiles(file.StructureFolderPath, $"{file.FormulaFileName}.sfd");
-                if (structureFile.Length > 0) FileStorageUtility.DeleteSfdFiles(structureFile);
+                if (structureFile.Length > 0) FileStorageUtility.DeleteFiles(structureFile);
 
                 var formulaFile = System.IO.Directory.GetFiles(Path.GetDirectoryName(file.FormulaFilePath), $"{file.FormulaFileName}.fgt");
-                if (formulaFile.Length > 0) FileStorageUtility.DeleteSfdFiles(formulaFile);
+                if (formulaFile.Length > 0) FileStorageUtility.DeleteFiles(formulaFile);
 
                 // delete the previous run log_smiles.smi file if exist 
                 var logSmileFile = System.IO.Directory.GetFiles(Path.GetDirectoryName(file.FormulaFilePath), $"log_smiles.smi");
-                if (logSmileFile.Length > 0) FileStorageUtility.DeleteSfdFiles(logSmileFile);
+                if (logSmileFile.Length > 0) FileStorageUtility.DeleteFiles(logSmileFile);
             }
 
             executeProcess();

--- a/MsfinderConsoleApp/Process/AnnotateProcess.cs
+++ b/MsfinderConsoleApp/Process/AnnotateProcess.cs
@@ -96,6 +96,10 @@ namespace Riken.Metabolomics.MsfinderConsoleApp.Process {
 
                 var formulaFile = System.IO.Directory.GetFiles(Path.GetDirectoryName(file.FormulaFilePath), $"{file.FormulaFileName}.fgt");
                 if (formulaFile.Length > 0) FileStorageUtility.DeleteSfdFiles(formulaFile);
+
+                // delete the previous run log_smiles.smi file if exist 
+                var logSmileFile = System.IO.Directory.GetFiles(Path.GetDirectoryName(file.FormulaFilePath), $"log_smiles.smi");
+                if (logSmileFile.Length > 0) FileStorageUtility.DeleteSfdFiles(logSmileFile);
             }
 
             executeProcess();

--- a/MsfinderConsoleApp/Process/MsSearchProcess.cs
+++ b/MsfinderConsoleApp/Process/MsSearchProcess.cs
@@ -105,7 +105,7 @@ namespace Riken.Metabolomics.MsfinderConsoleApp.Process
                 foreach (var rawData in rawDataList)
                 {
                     var structureFiles = System.IO.Directory.GetFiles(file.StructureFolderPath, "*.sfd");
-                    if (structureFiles.Length > 0) FileStorageUtility.DeleteSfdFiles(structureFiles);
+                    if (structureFiles.Length > 0) FileStorageUtility.DeleteFiles(structureFiles);
 
                     if (System.IO.File.Exists(file.FormulaFilePath))
                     {

--- a/MsfinderConsoleApp/Process/PredictProcess.cs
+++ b/MsfinderConsoleApp/Process/PredictProcess.cs
@@ -280,7 +280,7 @@ namespace Riken.Metabolomics.MsfinderConsoleApp.Process
                 foreach (var rawData in rawDataList)
                 {
                     var structureFiles = System.IO.Directory.GetFiles(file.StructureFolderPath, "*.sfd");
-                    if (structureFiles.Length > 0) FileStorageUtility.DeleteSfdFiles(structureFiles);
+                    if (structureFiles.Length > 0) FileStorageUtility.DeleteFiles(structureFiles);
 
                     if (System.IO.File.Exists(file.FormulaFilePath))
                     {

--- a/testdata/expected/log_smiles_expected.smi
+++ b/testdata/expected/log_smiles_expected.smi
@@ -1,0 +1,1 @@
+Cl[Si]1Oc2ccccc2O1.[C-]#[O+].[C-]#[O+].[CH]1C=CC=C1.[Fe]

--- a/testdata/input/test_log.msp
+++ b/testdata/input/test_log.msp
@@ -1,0 +1,37 @@
+FORMULA: C13H9ClFeO4Si
+COMMENT: SpectrumID: 1519953; Source: C4-1998-38-3; Class: Benzenoids; CASRN not real!
+NAME: ((.eta.5-Cyclopentadienylironbiscarbonyl)(1,2-phenylenedioxysilyl)chloride complex
+INCHI: InChI=1S/C6H4ClO2Si.C5H5.2CO.Fe/c7-10-8-5-3-1-2-4-6(5)9-10;1-2-4-5-3-1;2*1-2;/h1-4H;1-5H;;;
+SMILES: Cl[Si]1Oc2ccccc2O1.[C-]#[O+].[C-]#[O+].[CH]1C=CC=C1.[Fe]
+NUM PEAKS: 3
+292.0       999.0
+314.0       118.89
+348.0       734.24
+
+FORMULA: C13H14O
+COMMENT: SpectrumID: 1752764; Source: A1-13-956/SMS7-13; DOI: 10.1021/ol1029996; QI: 383; Class: Benzene and substituted derivatives; CASRN not real! |RI:1588|
+NAME: ((1R*,2R*)-1-Methyl-2-phenylethynylcyclopropyl)methanol
+RETENTIONINDEX: 1588.0
+INCHI: InChI=1S/C13H14O/c1-13(10-14)9-12(13)8-7-11-5-3-2-4-6-11/h2-6,12,14H,9-10H2,1H3/t12-,13-/m0/s1
+SMILES: C[C@@]1(CO)C[C@@H]1C#Cc1ccccc1
+NUM PEAKS: 20
+51.0        89.92
+63.0        89.92
+77.0        179.84
+88.0        39.96
+89.0        59.95
+91.0        49.95
+102.0       149.86
+113.0       49.95
+115.0       229.79
+127.0       139.87
+128.0       999.0
+129.0       199.82
+144.0       99.91
+155.0       119.89
+156.0       14.89
+157.0       1.1
+158.0       0.1
+186.0       39.96
+187.0       5.89
+188.0       0.5


### PR DESCRIPTION
This PR include the following:

- added functionality to log smile in smi format for those spectra for which structure files are not produced.
- added a message to the console if the count of data, formulaResults, and sfdResults are not equal.
- added test and testdata

closes #25 